### PR TITLE
Feature/card factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea/*

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -1,12 +1,14 @@
 import { CardType, TabletopCard, TabletopObject } from './Tabletop';
 import { isValidHttpUrl } from './Utils';
 
-export const SCRYFALL_CARD_BACK_IMAGE_URL = "https://img.scryfall.com/errors/missing.jpg";
+export const MTGSAGA_BACK_IMAGE_URL = "https://imgur.com/GLn8lMl.jpg";
+export const CLASSIC_BACK_IMAGE_URL = "https://i.imgur.com/vHgirGT.jpg";
+export const DEFAULT_CARD_BACK_IMAGE_URL = MTGSAGA_BACK_IMAGE_URL;
 
 const FORMAT_MTGO = /(?<quantity>\d+)\s+(?<card>.*?)\s+\((?<set>.+)\)(\s+(?<number>\d+[ps]?))/;
 const FORMAT_MTGA = /(?<quantity>\d+)\s+(?<card>.*)/;
 
-let cardBack = SCRYFALL_CARD_BACK_IMAGE_URL;
+let cardBack = DEFAULT_CARD_BACK_IMAGE_URL;
 function getCardBack() {
     return cardBack;
 }
@@ -14,7 +16,7 @@ export function setCardBack(tmpCardBack: string) {
     if (tmpCardBack.trim() !== "" && isValidHttpUrl(tmpCardBack)) {
         cardBack = tmpCardBack;
     } else {
-        cardBack = SCRYFALL_CARD_BACK_IMAGE_URL;
+        cardBack = DEFAULT_CARD_BACK_IMAGE_URL;
     }
 }
 
@@ -40,8 +42,8 @@ export default class Card {
         this.name = name;
         this.numInstances = num_instances;
         this.cardType = type;
-        this.back_url = SCRYFALL_CARD_BACK_IMAGE_URL;
-        this.front_url = SCRYFALL_CARD_BACK_IMAGE_URL;
+        this.back_url = DEFAULT_CARD_BACK_IMAGE_URL;
+        this.front_url = DEFAULT_CARD_BACK_IMAGE_URL;
         this.uri = "";
         this.tokens = [];
         this.failed = false;

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -1,7 +1,7 @@
 import { CardType, TabletopCard, TabletopObject } from './Tabletop';
 import { isValidHttpUrl } from './Utils';
 
-export const MTGSAGA_BACK_IMAGE_URL = "https://imgur.com/GLn8lMl.jpg";
+export const MTGSAGA_BACK_IMAGE_URL = "https://i.imgur.com/GLn8lMl.jpg";
 export const CLASSIC_BACK_IMAGE_URL = "https://i.imgur.com/vHgirGT.jpg";
 export const DEFAULT_CARD_BACK_IMAGE_URL = MTGSAGA_BACK_IMAGE_URL;
 

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -28,7 +28,7 @@ type Token = {
 export default class Card {
     name: string;
     collectorNumber: string;
-    setCode: string;
+    expansionCode: string;
     numInstances: number;
     cardType: CardType;
     back_url: string;
@@ -49,7 +49,7 @@ export default class Card {
         this.failed = false;
         this.id = -1;
         this.collectorNumber = "";
-        this.setCode = "";
+        this.expansionCode = "";
     }
 
     setFrontUrl(url: string) {
@@ -172,7 +172,7 @@ export default class Card {
             if (m && m.groups) {
                 let card = new Card(m.groups.card, Number(m.groups.quantity), type);
                 card.collectorNumber = m.groups.number;
-                card.setCode = m.groups.set;
+                card.expansionCode = m.groups.set;
 
                 return card;
             }
@@ -189,8 +189,8 @@ export default class Card {
     }
 
     getScryfallQueryUrl(): URL {
-        if (this.collectorNumber && this.setCode) {
-            return new URL('https://api.scryfall.com/cards/'+this.setCode.toLowerCase()+'/'+this.collectorNumber);
+        if (this.collectorNumber && this.expansionCode) {
+            return new URL('https://api.scryfall.com/cards/'+this.expansionCode.toLowerCase()+'/'+this.collectorNumber);
         }
 
         const url = new URL('https://api.scryfall.com/cards/named');

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -5,9 +5,6 @@ export const MTGSAGA_BACK_IMAGE_URL = "https://i.imgur.com/GLn8lMl.jpg";
 export const CLASSIC_BACK_IMAGE_URL = "https://i.imgur.com/vHgirGT.jpg";
 export const DEFAULT_CARD_BACK_IMAGE_URL = MTGSAGA_BACK_IMAGE_URL;
 
-const FORMAT_MTGO = /(?<quantity>\d+)\s+(?<card>.*?)\s+\((?<set>.+)\)(\s+(?<number>\d+[ps]?))/;
-const FORMAT_MTGA = /(?<quantity>\d+)\s+(?<card>.*)/;
-
 let cardBack = DEFAULT_CARD_BACK_IMAGE_URL;
 function getCardBack() {
     return cardBack;
@@ -166,7 +163,19 @@ export default class Card {
         }
     }
 
+    /**
+     * Card factory from a line of text
+     *
+     * This method uses `RegExp` to validate usual decklist patterns, and then capture content parts
+     * through javascript regexp results `group` property.
+     * This allow a self-documenting RegExp, and a more readable code where named capture groups.
+     *
+     * @see https://javascript.info/regexp-groups
+     * @param line
+     * @param type
+     */
     static fromLine(line: string, type: CardType = CardType.Default): Card {
+        const FORMAT_MTGO = /(?<quantity>\d+)\s+(?<card>.*?)\s+\((?<set>.+)\)(\s+(?<number>\d+[ps]?))/;
         if (FORMAT_MTGO.test(line)) {
             let m = FORMAT_MTGO.exec(line);
             if (m && m.groups) {
@@ -178,6 +187,7 @@ export default class Card {
             }
         }
 
+        const FORMAT_MTGA = /(?<quantity>\d+)\s+(?<card>.*)/;
         if (FORMAT_MTGA.test(line)) {
             let m = FORMAT_MTGA.exec(line);
             if (m && m.groups) {

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -165,7 +165,6 @@ export default class Card {
     }
 
     static fromLine(line: string, type: CardType = CardType.Default): Card {
-        console.log(FORMAT_MTGO.test(line));
         if (FORMAT_MTGO.test(line)) {
             let m = FORMAT_MTGO.exec(line);
             if (m && m.groups) {
@@ -188,7 +187,6 @@ export default class Card {
     }
 
     getScryfallQueryUrl(): URL {
-        console.log(this.collectorNumber, this.setCode);
         if (this.collectorNumber && this.setCode) {
             return new URL('https://api.scryfall.com/cards/'+this.setCode.toLowerCase()+'/'+this.collectorNumber);
         }

--- a/src/DeckBuilder.tsx
+++ b/src/DeckBuilder.tsx
@@ -65,14 +65,11 @@ async function download(form: any): Promise<string> {
         if (line === "" || line.startsWith("//")) {
             return;
         }
-        line = line.trim();
-        let numInstances = getNumInstances(line);
-        let name = getName(line);
-        let tmpCard = new Card(name, numInstances, CardType.Default);
+        let tmpCard = Card.fromLine(line.trim());
         tmpCard.setBackUrl(cardBack);
 
         if (hasCommander) {
-            let isCommander = compareToCommanders(commanders, name);
+            let isCommander = compareToCommanders(commanders, tmpCard.name);
             if (isCommander) {
                 console.log("Found commander in decklist as well");
                 tmpCard.setCardType(CardType.Commander);

--- a/src/DeckBuilder.tsx
+++ b/src/DeckBuilder.tsx
@@ -69,7 +69,7 @@ async function download(form: any): Promise<string> {
         tmpCard.setBackUrl(cardBack);
 
         if (hasCommander) {
-            let isCommander = compareToCommanders(commanders, tmpCard.name);
+            let isCommander = compareToCommanders(commanders, getName(tmpCard.name));
             if (isCommander) {
                 console.log("Found commander in decklist as well");
                 tmpCard.setCardType(CardType.Commander);

--- a/src/DeckBuilder.tsx
+++ b/src/DeckBuilder.tsx
@@ -1,4 +1,4 @@
-import Card, {SCRYFALL_CARD_BACK_IMAGE_URL} from './Card';
+import Card, {DEFAULT_CARD_BACK_IMAGE_URL} from './Card';
 import { CardType, generateTabletopOutput } from './Tabletop';
 import { getDeckFromURL } from './DeckURL';
 import { getName, getNumInstances, compareToCommanders, downloadPrompt } from './Utils';
@@ -18,7 +18,7 @@ async function download(form: any): Promise<string> {
     let partner: string = form.partner;
     let cardBack: string = form.cardback.trim(); 
     if (!isValidHttpUrl(cardBack)) {
-        cardBack = SCRYFALL_CARD_BACK_IMAGE_URL;
+        cardBack = DEFAULT_CARD_BACK_IMAGE_URL;
     }
 
     // CustomCardBack

--- a/src/DeckInfo.tsx
+++ b/src/DeckInfo.tsx
@@ -303,7 +303,7 @@ export default function InfoForm() {
                         name="errors"
                         label="Failed to get the following card(s)"
                         helperText={"Edit these in the textbox above and try again. " +
-                            "Follow the format: <number> <card name>"}
+                            "Follow the format: <number> <card name> or <number> <card name> (<set>) <collectorNumber>"}
                         value={errors}
                         InputLabelProps={{ shrink: true }}
                         fullWidth

--- a/src/DeckInfo.tsx
+++ b/src/DeckInfo.tsx
@@ -16,6 +16,7 @@ import step1 from './images/step-1.svg' // relative path to image
 import step2 from './images/step-2.svg' // relative path to image
 import step3 from './images/step-3.svg' // relative path to image
 import { FormGroup, Switch, FormControlLabel, Tooltip, SvgIcon, Paper, CardMedia, Card } from '@material-ui/core';
+import {DEFAULT_CARD_BACK_IMAGE_URL} from "./Card";
 
 export default function InfoForm() {
     const classes = useStyles();
@@ -228,7 +229,7 @@ export default function InfoForm() {
                             <FormControlLabel
                                 control={<Switch disabled={form.decklist === ""} checked={customCardBackChecked} onChange={(e) => {
                                     setCustomCardBackChecked(e.target.checked);
-                                    setForm({ ...form, "cardback": "https://imgur.com/GLn8lMl.jpg" });
+                                    setForm({ ...form, "cardback": DEFAULT_CARD_BACK_IMAGE_URL });
                                 }} name="cardback-switch" size="small" />}
                                 label="Custom Card Back"
                             />
@@ -250,7 +251,7 @@ export default function InfoForm() {
                                         }                             
                                     }}
                                     InputLabelProps={{ shrink: true }}
-                                    placeholder={"https://imgur.com/GLn8lMl.jpg"}
+                                    placeholder={DEFAULT_CARD_BACK_IMAGE_URL}
                                     helperText="Paste a URL to a card image with a ratio of 488 × 680"
                                     fullWidth
                                 />

--- a/src/SealedInfo.tsx
+++ b/src/SealedInfo.tsx
@@ -110,7 +110,7 @@ export default function InfoForm() {
                         name="errors"
                         label="Failed to get the following card(s)"
                         helperText={"Edit these in the textbox above and try again. " +
-                            "Follow the format: <number> <card name>"}
+                            "Follow the format: <number> <card name> or <number> <card name> (<set>) <collectorNumber>"}
                         value={errors}
                         InputLabelProps={{ shrink: true }}
                         fullWidth

--- a/src/__tests__/Card.ts
+++ b/src/__tests__/Card.ts
@@ -6,3 +6,51 @@ it('can be constructed', () => {
     expect(card.name).toEqual('Saltblast');
     expect(card.numInstances).toEqual(2);
 });
+
+it('fromLine factory can parse MTGA format, with comma', () => {
+   const card = Card.fromLine("1 Animar, Soul of Elements (A25) 196");
+   expect(card.name).toEqual('Animar, Soul of Elements');
+   expect(card.numInstances).toEqual(1);
+   expect(card.setCode).toEqual('A25');
+   expect(card.collectorNumber).toEqual("196");
+});
+
+it('fromLine factory can parse MTGA format, with comma', () => {
+    const card = Card.fromLine("1 Acidic Slime (ZNC) 59");
+    expect(card.name).toEqual('Acidic Slime');
+    expect(card.numInstances).toEqual(1);
+    expect(card.setCode).toEqual('ZNC');
+    expect(card.collectorNumber).toEqual("59");
+});
+
+it('fromLine factory can parse MTGA format, with promo', () => {
+   const card = Card.fromLine("1 Vivien, Monsters' Advocate (PIKO) 175p");
+   expect(card.name).toEqual('Vivien, Monsters\' Advocate');
+   expect(card.numInstances).toEqual(1);
+   expect(card.setCode).toEqual('PIKO');
+   expect(card.collectorNumber).toEqual("175p");
+});
+
+it('fromLine factory can parse MTGO format', () => {
+   const card = Card.fromLine("1 Terastodon");
+   expect(card.name).toEqual('Terastodon');
+   expect(card.numInstances).toEqual(1);
+   expect(card.setCode).toEqual('');
+   expect(card.collectorNumber).toEqual('');
+});
+
+it('fromLine factory can parse MTGO format, with comma', () => {
+   const card = Card.fromLine("1 Vivien, Monsters' Advocate");
+   expect(card.name).toEqual('Vivien, Monsters\' Advocate');
+   expect(card.numInstances).toEqual(1);
+   expect(card.setCode).toEqual('');
+   expect(card.collectorNumber).toEqual('');
+});
+
+it('fromLine factory will fallback to cardname', () => {
+   const card = Card.fromLine("Saltblast");
+   expect(card.name).toEqual('Saltblast');
+   expect(card.numInstances).toEqual(1);
+   expect(card.setCode).toEqual('');
+   expect(card.collectorNumber).toEqual('');
+});

--- a/src/__tests__/Card.ts
+++ b/src/__tests__/Card.ts
@@ -11,7 +11,7 @@ it('fromLine factory can parse MTGA format, with comma', () => {
    const card = Card.fromLine("1 Animar, Soul of Elements (A25) 196");
    expect(card.name).toEqual('Animar, Soul of Elements');
    expect(card.numInstances).toEqual(1);
-   expect(card.setCode).toEqual('A25');
+   expect(card.expansionCode).toEqual('A25');
    expect(card.collectorNumber).toEqual("196");
 });
 
@@ -19,7 +19,7 @@ it('fromLine factory can parse MTGA format, with comma', () => {
     const card = Card.fromLine("1 Acidic Slime (ZNC) 59");
     expect(card.name).toEqual('Acidic Slime');
     expect(card.numInstances).toEqual(1);
-    expect(card.setCode).toEqual('ZNC');
+    expect(card.expansionCode).toEqual('ZNC');
     expect(card.collectorNumber).toEqual("59");
 });
 
@@ -27,7 +27,7 @@ it('fromLine factory can parse MTGA format, with promo', () => {
    const card = Card.fromLine("1 Vivien, Monsters' Advocate (PIKO) 175p");
    expect(card.name).toEqual('Vivien, Monsters\' Advocate');
    expect(card.numInstances).toEqual(1);
-   expect(card.setCode).toEqual('PIKO');
+   expect(card.expansionCode).toEqual('PIKO');
    expect(card.collectorNumber).toEqual("175p");
 });
 
@@ -35,7 +35,7 @@ it('fromLine factory can parse MTGO format', () => {
    const card = Card.fromLine("1 Terastodon");
    expect(card.name).toEqual('Terastodon');
    expect(card.numInstances).toEqual(1);
-   expect(card.setCode).toEqual('');
+   expect(card.expansionCode).toEqual('');
    expect(card.collectorNumber).toEqual('');
 });
 
@@ -43,7 +43,7 @@ it('fromLine factory can parse MTGO format, with comma', () => {
    const card = Card.fromLine("1 Vivien, Monsters' Advocate");
    expect(card.name).toEqual('Vivien, Monsters\' Advocate');
    expect(card.numInstances).toEqual(1);
-   expect(card.setCode).toEqual('');
+   expect(card.expansionCode).toEqual('');
    expect(card.collectorNumber).toEqual('');
 });
 
@@ -51,6 +51,6 @@ it('fromLine factory will fallback to cardname', () => {
    const card = Card.fromLine("Saltblast");
    expect(card.name).toEqual('Saltblast');
    expect(card.numInstances).toEqual(1);
-   expect(card.setCode).toEqual('');
+   expect(card.expansionCode).toEqual('');
    expect(card.collectorNumber).toEqual('');
 });

--- a/src/__tests__/Card.ts
+++ b/src/__tests__/Card.ts
@@ -1,0 +1,8 @@
+import Card from '../Card';
+import {CardType} from "../Tabletop";
+
+it('can be constructed', () => {
+    const card = new Card("Saltblast", 2, CardType.Default);
+    expect(card.name).toEqual('Saltblast');
+    expect(card.numInstances).toEqual(2);
+});


### PR DESCRIPTION
In this PR I've addressed the MTGA file format support as seen in issue #18 .


* `Card.collectorNumber` and `Card.setCode` added to `Card` property
* `Card.fromLine` can read a line and create a Card object supporting MTGA, MTGO or fallback format
* I added JEST test suite to validate the `Card.fromLine` factory behavior
* `Card.query` property is replaced by `Card.getScryfallQueryUrl` that can change URL depending on the available data (set and collectornumber)
* I've changed the error message to describe the MTGA format.

