### PR TITLE
Allow a deck to have multiple tokens with the same name.

### DIFF
--- a/src/DeckBuilder.tsx
+++ b/src/DeckBuilder.tsx
@@ -116,16 +116,17 @@ async function download(form: any): Promise<string> {
     // Postprocess tokens, flip and additional cards
     let postPromises: any[] = [];
     let tokens: { [key: string]: boolean } = {};
+    let flips: { [key: string]: boolean } = {};
 
     cards.forEach(card => {
         // Handle tokens
         if (card.tokens.length !== 0) {
             card.tokens.forEach((token: any) => {
                 // if this token is already present in the list.
-                if (token.name in tokens) {
+                if (token.uri in tokens) {
                     return;
                 }
-                tokens[token.name] = true;
+                tokens[token.uri] = true;
                 let tmpCard = new Card("", 1, CardType.Additional);
                 tmpCard.setUri(token.uri);
                 cards.push(tmpCard);
@@ -135,7 +136,7 @@ async function download(form: any): Promise<string> {
         // Handle flip cards
         if (card.cardType === CardType.Flip) {
             // if we already have a double backed token for this card we just modify this one to go in the main deck.
-            if (card.name in tokens) {
+            if (card.name in flips) {
                 card.setCardType(CardType.Default);
                 card.setBackUrl("");
                 return;
@@ -150,7 +151,7 @@ async function download(form: any): Promise<string> {
             // make sure 1 double faced card gets put in the token stack
             card.setCardType(CardType.Additional);
             card.setNumInstances(1);
-            tokens[card.name] = true;
+            flips[card.name] = true;
         }
     });
 


### PR DESCRIPTION
When you make a deck containing for example `Esika's Chariot` and `Leonin Warleader` it requires two different tokens named `Cat` (a 1/1 white with lifelink and a 2/2 green). By checking duplicates on the uri instead of the name this can be allowed.

The downside is that when cards reference the same token from different sets this leads to functional duplicates with different art. See attached screenshots.

<img width="711" alt="Tabletop_Simulator 2022'06'12 00'36'03" src="https://user-images.githubusercontent.com/8057570/173207265-0dce6fac-b129-43a9-a89a-b0b7bf22c690.png">
<img width="530" alt="Tabletop_Simulator 2022'06'12 00'35'53" src="https://user-images.githubusercontent.com/8057570/173207272-5d62715e-a6e3-4db4-a3bc-ce2074dc2b83.png">